### PR TITLE
More stuff about rainbows.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -7,7 +7,7 @@
 @import url("https://netox005.github.io/Dubtrack/css/skynet.css"); /* @netuxbot custom chat */
 @import url("https://netox005.github.io/Dubtrack/css/phonefix.css"); /* Phone Fixes */
 @import url("https://netox005.github.io/Dubtrack/css/animations.css"); /* Animations */
-@import url("https://hebgbs.github.io/rainbowstuff.css"); /* Rainbowstuff (Progress bar and volume bar) */
+@import url("https://hebgbs.github.io/rainbowNB3.css"); /* Rainbowstuff (Progress bar and volume bar) */
 
 /* Video next to chat */
 @media screen and (min-width: 72em) {
@@ -113,12 +113,6 @@ img.emoji.twitch-emoji[alt="angelthump"], img.emoji.twitch-emoji[alt="taxibro"] 
     color: red;
     font-size: 1.5rem;
 }
-
-/* Rainbowstuff.css fixes */
-#player-controller .left, #player-controller .left .progressBg, .playerPreview .loaded, .playerPreview .progress { animation-duration: 25s !important; }
-#volume-div, #volume-div > div { animation: none !important; }
-#volume-div { background: #878C8E !important; }
-#volume-div > div { background: #0ff !important }
 
 /* Other fixes */
 .medium { top: 54px !important; } /* Background Fix */


### PR DESCRIPTION
Replaced import "rainbowstuff.css" with "rainbowNB3.css" and removed the rainbowstuff fixes as none of them are necessary.

This change will remove the rainbow gradient and animation keyframes for the volume bar.
